### PR TITLE
5 implement openai model as an option for the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ You can choose which Ollama model Cbot uses by passing one of these flags before
   
 - `-l32` : use `llama3.2` (default)  
 - `-ds`  : use `deepseek-r1`
+- `-oa4m`: use `openai o4-mini`
   
 Example:
   
 ```
 cbot-cli -l32 -g "List files in my home directory"
 cbot-cli -ds -g "Explain how a for loop works in Python"
+cbot-cli -oa4m -g "Who is the president of the United States?"
 ```
 
 You can also call cbot with a **-s** option. This will save any command as a shortcut with whatever name you choose. The first parameter is the name of the command and the second is the command itself in quotes.

--- a/cbot/cbot_cli.py
+++ b/cbot/cbot_cli.py
@@ -6,22 +6,36 @@ import json
 from os.path import expanduser
 import os
 import pyperclip
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 def call_model(prompt, system_message="", model="llama3.2"):
     full_prompt = f"{system_message}\n{prompt}" if system_message else prompt
-    # This is a text completion, not a chat completion. Will need to refactor to the messages array to add context.
-    payload = {
-        "model": model,
-        "prompt": full_prompt,
-        "stream": False
-    }
-    # Fully local inference via ollama
-    response = requests.post("http://localhost:11434/api/generate",
-                             json=payload)
 
-    result = response.json()
-    return result["response"]
+    if "openai" in model:
+        client = OpenAI()
+
+        result = client.responses.create(
+            model="o4-mini",
+            input=full_prompt
+        ).output_text
+    else:
+        # This is a text completion, not a chat completion. Will need to refactor to the messages array to add context.
+        payload = {
+            "model": model,
+            "prompt": full_prompt,
+            "stream": False
+        }
+        # Fully local inference via ollama
+        response = requests.post("http://localhost:11434/api/generate",
+                                 json=payload)
+
+        result = response.json()["response"]
+
+    return result
 
 
 def run_cbot(argv):
@@ -38,6 +52,8 @@ def run_cbot(argv):
             model_name = "llama3.2"
         elif arg == "-ds":
             model_name = "deepseek-r1"
+        elif arg == "-oa4m":
+            model_name = "openai-o4-mini"
         else:
             filtered_argv.append(arg)
     argv = filtered_argv

--- a/cbot/cbot_cli.py
+++ b/cbot/cbot_cli.py
@@ -6,7 +6,7 @@ import json
 from os.path import expanduser
 import os
 import pyperclip
-from openai import OpenAI
+from openai import OpenAI, OpenAIError, RateLimitError
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -16,12 +16,22 @@ def call_model(prompt, system_message="", model="llama3.2"):
     full_prompt = f"{system_message}\n{prompt}" if system_message else prompt
 
     if "openai" in model:
-        client = OpenAI()
+        try:
+            client = OpenAI()
 
-        result = client.responses.create(
-            model="o4-mini",
-            input=full_prompt
-        ).output_text
+            result = client.responses.create(
+                model="o4-mini",
+                input=full_prompt
+            ).output_text
+        except RateLimitError as e:
+            print("Rate Limit Error Ocurred: ", e)
+            print(
+                "Insufficient quota: Please check OpenAI API usage and billing details.")
+            sys.exit(1)
+        except OpenAIError as e:
+            print("Open AI Error Occurred: ", e)
+            sys.exit(1)
+
     else:
         # This is a text completion, not a chat completion. Will need to refactor to the messages array to add context.
         payload = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ classifiers = [
 ]
 dependencies = [
     "requests",
-    "pyperclip"
+    "pyperclip",
+    "openai",
+    "python-dotenv"
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ setup(
     packages=find_packages(),
     install_requires=[
         "requests",
-        "pyperclip"
+        "pyperclip",
+        "openai",
+        "python-dotenv"
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
If user provides "-oa4m" flag as an argument, user will be able to use OpenAI's o4-mini model. If API key is not provided, then throws an informative error and exits cleanly. If there is not enough credits or an issue with the billing, then throws an error about billing and exits cleanly.